### PR TITLE
proposed changes to CWL - remove cdse and rename workflow ID

### DIFF
--- a/resources/opensar.cwl
+++ b/resources/opensar.cwl
@@ -8,7 +8,7 @@ $graph:
   - class: Workflow
     label: OST Notebook 1
     doc: Preprocessing an S1 image with OST
-    id: main
+    id: opensartoolkit
     requirements: []
     inputs:
       input:
@@ -41,14 +41,6 @@ $graph:
             - BICUBIC_INTERPOLATION
         label: Resampling method
         doc: Resampling method to use
-      cdse-user:
-        type: string
-        label: CDSE user
-        doc: CDSE user name
-      cdse-password:
-        type: string
-        label: CDSE password
-        doc: Password for the specified CDSE user
       dry-run:
         type: boolean
         label: Dry run
@@ -69,8 +61,6 @@ $graph:
           ard-type: ard-type
           with-speckle-filter: with-speckle-filter
           resampling-method: resampling-method
-          cdse-user: cdse-user
-          cdse-password: cdse-password
           dry-run: dry-run
         out:
           - ost_ard
@@ -119,11 +109,11 @@ $graph:
         inputBinding:
           prefix: --resampling-method
       cdse-user:
-        type: string
+        type: string?
         inputBinding:
           prefix: --cdse-user
       cdse-password:
-        type: string
+        type: string?
         inputBinding:
           prefix: --cdse-password
       dry-run:


### PR DESCRIPTION
Two main edits:

- change id, as it shouldnt be "main", but more specific to the application

- The CDSE credentials must not be passed to the CWL workflow as parameters, as the EO data access (ie stage-in) is handled by the Exploitation platform. Hence the OpenSarToolkit should receive the path to the directory that contains the catalog.json and the STAC Item with all assets. 

   