### PR TITLE
allow to set output_projection

### DIFF
--- a/ost/app/preprocessing.py
+++ b/ost/app/preprocessing.py
@@ -37,6 +37,11 @@ ITEM_ID = "result-item"
     type=click.Choice(["BILINEAR_INTERPOLATION", "BICUBIC_INTERPOLATION"]),
     default="BILINEAR_INTERPOLATION",
 )
+@click.option(
+    "--output-projection",    
+    default=42001,
+    help="The EPSG code (integer) of the output projection. The default is 42001, which allows SNAP to select the appropriate UTM projection for the given product or AOI."
+)
 @click.option("--cdse-user", default="dummy")
 @click.option("--cdse-password", default="dummy")
 @click.option(
@@ -64,6 +69,7 @@ def run(
     cdse_password: str,
     dry_run: bool,
     wipe_cwd: bool,
+    output_projection: int
 ):
     horizontal_line = "-" * 79  # Used in log output
 
@@ -138,6 +144,9 @@ def run(
     single_ard["dem"][
         "image_resampling"
     ] = resampling_method  # default: BICUBIC_INTERPOLATION
+    single_ard["dem"][
+        "out_projection"
+    ] = output_projection
     single_ard["to_tif"] = True
     # single_ard['product_type'] = 'RTC-gamma0'
 

--- a/resources/opensar.cwl
+++ b/resources/opensar.cwl
@@ -19,6 +19,10 @@ $graph:
         type: int
         label: Resolution
         doc: Resolution in metres
+      output-projection:
+        type: int
+        label: Projection
+        doc: Output projection as EPSG code (integer), default is 42001 which selects the appropriate UTM projection.
       ard-type:
         type:
           type: enum
@@ -86,7 +90,11 @@ $graph:
       resolution:
         type: int
         inputBinding:
-          prefix: --resolution
+          prefix: --resolution      
+      output-projection:
+        type: int
+        inputBinding:
+          prefix: --output-projection
       ard-type:
         type:
           type: enum


### PR DESCRIPTION
A lot of Sentinel 1/2 processing is done in UTM instead of EPSG:4326. I propose to make UTM the default, and allow to configure output projection from CLI.